### PR TITLE
Add new optional parameter to specify the volume type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Required variables:
 - `openstack_volume_vmname`: The name of the instance the volume should be attached to
 - `openstack_volume_name`: The name of the volume
 - `openstack_volume_device`: The device name of the volume in the instance (default: automatically determined by Openstack)
+- `openstack_volume_type`: The type of volume
 
 
 Author Information

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
     display_name: "{{ openstack_volume_vmname }}-{{ openstack_volume_name }}"
     snapshot_id: "{{ openstack_volume_snapshot | default(omit) }}"
     volume: "{{ openstack_volume_source | default(omit) }}"
+    volume_type: "{{ openstack_volume_type | default(omit) }}"
 
 - name: openstack volume | attach volume to host
   os_server_volume:


### PR DESCRIPTION
By default, the parameter should be omitted.

Proposed tag: 1.2.0