### PR TITLE
Add intermediate snapshot logic for cloning a volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ Required variables:
 - `openstack_volume_type`: The type of volume
 - `openstack_volume_source`: The name of the volume to clone.
 
-If `openstack_volume_source` is specified, the role will create a temporary
-snapshot and use this snapshot as the source of the new volume.
+If `openstack_volume_source` is specified, the role will create an intermediate
+volume snapshot, named after `openstack_volume_name` and suffixed with the 
+creation timestamp, and use this snapshot as the source of the new volume. The
+lifecycle of this snapshot will need to be managed separately similarly to the
+lifecycle of the new volume.
 
 
 Author Information

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Required variables:
 - `openstack_volume_name`: The name of the volume
 - `openstack_volume_device`: The device name of the volume in the instance (default: automatically determined by Openstack)
 - `openstack_volume_type`: The type of volume
+- `openstack_volume_source`: The name of the volume to clone.
+
+If `openstack_volume_source` is specified, the role will create a temporary
+snapshot and use this snapshot as the source of the new volume.
 
 
 Author Information

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,42 +1,34 @@
 ---
 # tasks file for roles/openstack-volume-storage
 
-- block:
-    - name: openstack volume | create temporary snapshot name
-      set_fact:
-        openstack_volume_snapshot_name: >-
-          {{ openstack_volume_vmname }}-{{ openstack_volume_name }}-
-          {{ ansible_date_time.iso8601 }}
-      when: openstack_volume_source is defined
+- name: openstack volume | create temporary snapshot name
+  set_fact:
+    openstack_volume_snapshot_name: >-
+      {{ openstack_volume_vmname }}-{{ openstack_volume_name }}-
+      {{ ansible_date_time.iso8601 }}
+  when: openstack_volume_source is defined
 
-    - name: openstack volume | create snapshot
-      os_volume_snapshot:
-        state: present
-        display_name: "{{ openstack_volume_snapshot_name }}"
-        volume: "{{ openstack_volume_source }}"
-        force: true
-      register: results
-      when: openstack_volume_source is defined
+- name: openstack volume | create snapshot
+  os_volume_snapshot:
+    state: present
+    display_name: "{{ openstack_volume_snapshot_name }}"
+    volume: "{{ openstack_volume_source }}"
+    force: true
+  register: results
+  when: openstack_volume_source is defined
 
-    - name: openstack volume | create volume
-      os_volume:
-        state: present
-        size: "{{ openstack_volume_size }}"
-        display_name: >
-          {{ openstack_volume_vmname }}-{{ openstack_volume_name }}
-        snapshot_id: "{{ results.snapshot.id | default(omit) }}"
-        volume_type: "{{ openstack_volume_type | default(omit) }}"
+- name: openstack volume | create volume
+  os_volume:
+    state: present
+    size: "{{ openstack_volume_size }}"
+    display_name: >
+      {{ openstack_volume_vmname }}-{{ openstack_volume_name }}
+    snapshot_id: "{{ results.snapshot.id | default(omit) }}"
+    volume_type: "{{ openstack_volume_type | default(omit) }}"
 
-    - name: openstack volume | attach volume to host
-      os_server_volume:
-        state: present
-        server: "{{ openstack_volume_vmname }}"
-        volume: "{{ openstack_volume_vmname }}-{{ openstack_volume_name }}"
-        device: "{{ openstack_volume_device | default(omit) }}"
-  always:
-    - name: openstack volume | delete snapshot
-      os_volume_snapshot:
-        state: absent
-        display_name: "{{ openstack_volume_snapshot_name }}"
-        volume: "{{ openstack_volume_source }}"
-      when: openstack_volume_source is defined
+- name: openstack volume | attach volume to host
+  os_server_volume:
+    state: present
+    server: "{{ openstack_volume_vmname }}"
+    volume: "{{ openstack_volume_vmname }}-{{ openstack_volume_name }}"
+    device: "{{ openstack_volume_device | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,30 @@
 ---
 # tasks file for roles/openstack-volume-storage
 
+- name: openstack volume | create snapshot
+  os_volume_snapshot:
+    state: present
+    size: "{{ openstack_volume_size }}"
+    display_name: "{{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}"
+    volume: "{{ openstack_volume_source | default(omit) }}"
+    force: true
+  register: snapshot
+  when: openstack_volume_source is defined
+
 - name: openstack volume | create volume
   os_volume:
     state: present
     size: "{{ openstack_volume_size }}"
     display_name: "{{ openstack_volume_vmname }}-{{ openstack_volume_name }}"
-    snapshot_id: "{{ openstack_volume_snapshot | default(omit) }}"
-    volume: "{{ openstack_volume_source | default(omit) }}"
+    snapshot_id: "{{ snapshot.id | default(omit) }}"
     volume_type: "{{ openstack_volume_type | default(omit) }}"
+
+- name: openstack volume | delete snapshot
+  os_volume_snapshot:
+    state: absent
+    display_name: "{{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}"
+    volume: "{{ openstack_volume_source | default(omit) }}"
+  when: openstack_volume_source is defined
 
 - name: openstack volume | attach volume to host
   os_server_volume:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
       os_volume_snapshot:
         state: present
         display_name: "{{ openstack_volume_snapshot_name }}"
-        volume: "{{ openstack_volume_source | default(omit) }}"
+        volume: "{{ openstack_volume_source }}"
         force: true
       register: snapshot
       when: openstack_volume_source is defined
@@ -38,5 +38,5 @@
       os_volume_snapshot:
         state: absent
         display_name: "{{ openstack_volume_snapshot_name }}"
-        volume: "{{ openstack_volume_source | default(omit) }}"
+        volume: "{{ openstack_volume_source }}"
       when: openstack_volume_source is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - block:
     - name: openstack volume | create temporary snapshot name
       set_fact:
-        openstack_volume_snapshot_name: >
+        openstack_volume_snapshot_name: >-
           {{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}
       when: openstack_volume_source is defined
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
     - name: openstack volume | create temporary snapshot name
       set_fact:
         openstack_volume_snapshot_name: >-
-          {{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}
+          {{ openstack_volume_vmname }}-{{ openstack_volume_name }}-
+          {{ ansible_date_time.iso8601 }}
       when: openstack_volume_source is defined
 
     - name: openstack volume | create snapshot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
         display_name: "{{ openstack_volume_snapshot_name }}"
         volume: "{{ openstack_volume_source }}"
         force: true
-      register: snapshot
+      register: results
       when: openstack_volume_source is defined
 
     - name: openstack volume | create volume
@@ -23,9 +23,8 @@
         size: "{{ openstack_volume_size }}"
         display_name: >
           {{ openstack_volume_vmname }}-{{ openstack_volume_name }}
-        snapshot_id: "{{ snapshot.id | default(omit) }}"
+        snapshot_id: "{{ results.snapshot.id | default(omit) }}"
         volume_type: "{{ openstack_volume_type | default(omit) }}"
-
 
     - name: openstack volume | attach volume to host
       os_server_volume:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,8 @@
 - name: openstack volume | create temporary snapshot name
   set_fact:
     openstack_volume_snapshot_name: >-
-      {{ openstack_volume_vmname }}-{{ openstack_volume_name }}-
-      {{ ansible_date_time.iso8601 }}
+      {{ openstack_volume_vmname }}-{{ openstack_volume_name }}-{{
+         ansible_date_time.iso8601 }}
   when: openstack_volume_source is defined
 
 - name: openstack volume | create snapshot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,6 @@
     - name: openstack volume | create snapshot
       os_volume_snapshot:
         state: present
-        size: "{{ openstack_volume_size }}"
         display_name: >
           {{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}
         volume: "{{ openstack_volume_source | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,16 @@
 # tasks file for roles/openstack-volume-storage
 
 - block:
+    - name: openstack volume | create temporary snapshot name
+      set_fact:
+        openstack_volume_snapshot_name: >
+          {{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}
+      when: openstack_volume_source is defined
+
     - name: openstack volume | create snapshot
       os_volume_snapshot:
         state: present
-        display_name: >
-          {{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}
+        display_name: "{{ openstack_volume_snapshot_name }}"
         volume: "{{ openstack_volume_source | default(omit) }}"
         force: true
       register: snapshot
@@ -32,7 +37,6 @@
     - name: openstack volume | delete snapshot
       os_volume_snapshot:
         state: absent
-        display_name: >
-          {{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}
+        display_name: "{{ openstack_volume_snapshot_name }}"
         volume: "{{ openstack_volume_source | default(omit) }}"
       when: openstack_volume_source is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,34 +1,39 @@
 ---
 # tasks file for roles/openstack-volume-storage
 
-- name: openstack volume | create snapshot
-  os_volume_snapshot:
-    state: present
-    size: "{{ openstack_volume_size }}"
-    display_name: "{{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}"
-    volume: "{{ openstack_volume_source | default(omit) }}"
-    force: true
-  register: snapshot
-  when: openstack_volume_source is defined
+- block:
+    - name: openstack volume | create snapshot
+      os_volume_snapshot:
+        state: present
+        size: "{{ openstack_volume_size }}"
+        display_name: >
+          {{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}
+        volume: "{{ openstack_volume_source | default(omit) }}"
+        force: true
+      register: snapshot
+      when: openstack_volume_source is defined
 
-- name: openstack volume | create volume
-  os_volume:
-    state: present
-    size: "{{ openstack_volume_size }}"
-    display_name: "{{ openstack_volume_vmname }}-{{ openstack_volume_name }}"
-    snapshot_id: "{{ snapshot.id | default(omit) }}"
-    volume_type: "{{ openstack_volume_type | default(omit) }}"
+    - name: openstack volume | create volume
+      os_volume:
+        state: present
+        size: "{{ openstack_volume_size }}"
+        display_name: >
+          {{ openstack_volume_vmname }}-{{ openstack_volume_name }}
+        snapshot_id: "{{ snapshot.id | default(omit) }}"
+        volume_type: "{{ openstack_volume_type | default(omit) }}"
 
-- name: openstack volume | delete snapshot
-  os_volume_snapshot:
-    state: absent
-    display_name: "{{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}"
-    volume: "{{ openstack_volume_source | default(omit) }}"
-  when: openstack_volume_source is defined
 
-- name: openstack volume | attach volume to host
-  os_server_volume:
-    state: present
-    server: "{{ openstack_volume_vmname }}"
-    volume: "{{ openstack_volume_vmname }}-{{ openstack_volume_name }}"
-    device: "{{ openstack_volume_device | default(omit) }}"
+    - name: openstack volume | attach volume to host
+      os_server_volume:
+        state: present
+        server: "{{ openstack_volume_vmname }}"
+        volume: "{{ openstack_volume_vmname }}-{{ openstack_volume_name }}"
+        device: "{{ openstack_volume_device | default(omit) }}"
+  always:
+    - name: openstack volume | delete snapshot
+      os_volume_snapshot:
+        state: absent
+        display_name: >
+          {{ openstack_volume_source }}-{{ ansible_date_time.iso8601 }}
+        volume: "{{ openstack_volume_source | default(omit) }}"
+      when: openstack_volume_source is defined


### PR DESCRIPTION
Recent Embassy policies have impacted our workflow to clone volumes from existing running volumes as the writing speed (200Mbs) is now hitting timeouts for our TB scale volumes.

This PR creates an intermediate temporary snapshot that is used as the source of creation of the new volume leading to response times similar to the ones that have been used previously.